### PR TITLE
Update PropTypes import to match React versions v15.5+

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { ART, Text, View, ActivityIndicator, StyleSheet } from "react-native";
 
 const { Group, Shape, Surface } = ART;

--- a/package.json
+++ b/package.json
@@ -17,5 +17,9 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "react": "^16.2.0",
+    "prop-types": "^15.6.1"
+  }
 }


### PR DESCRIPTION
React version 15.5 moved 'PropTypes' out of 'react' and into 'prop-types'. Also added dependencies for react and prop-types to prevent similar issues in the future.
